### PR TITLE
Fix issue #9 Support ip4 when network device has ip6

### DIFF
--- a/util.go
+++ b/util.go
@@ -26,10 +26,12 @@ func findIP(iface net.Interface) (string, error) {
 	}
 	for _, addr := range addrs {
 		if ipnet, ok := addr.(*net.IPNet); ok {
-			return ipnet.IP.String(), nil
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String(), nil
+			}
 		}
 	}
-	return "", errors.New("Unable to find an IP for this interface")
+	return "", errors.New("Unable to find an IPv4 address for this interface")
 }
 
 // getAddress returns the address of the network interface to


### PR DESCRIPTION
IP.To4 returns nil for non-IPv4 addresses. Adds a check that ipnet.IP.To4 != nil to findIP to prevent it returning non-IPv4 addresses. Fixes #9.