### PR TITLE
fix empty content type error

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		w.Header().Set("Content-Disposition",
 			"attachment; filename="+content.Name())
 
-		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+		//w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
 		http.ServeFile(w, r, content.Path)
 		if content.ShouldBeDeleted {
 			if err := content.Delete(); err != nil {


### PR DESCRIPTION
if user's browser send a request that don't contain filed `content-type`, the fileServe will be quickly exit.

```
w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
```
so the code above is wrong.we don't need set it here, the  `serveContent`  function in  `fs.go`  will do it automatically for us.

```
	// If Content-Type isn't set, use the file's extension to find it, but
	// if the Content-Type is unset explicitly, do not sniff the type.
	ctypes, haveType := w.Header()["Content-Type"]
	var ctype string
	if !haveType {
		ctype = mime.TypeByExtension(filepath.Ext(name))
		if ctype == "" {
			// read a chunk to decide between utf-8 text and binary
			var buf [sniffLen]byte
			n, _ := io.ReadFull(content, buf[:])
			ctype = DetectContentType(buf[:n])
			_, err := content.Seek(0, io.SeekStart) // rewind to output whole file
			if err != nil {
				Error(w, "seeker can't seek", StatusInternalServerError)
				return
			}
		}
		w.Header().Set("Content-Type", ctype)
	} else if len(ctypes) > 0 {
		ctype = ctypes[0]
	}
```