### PR TITLE
Check for link local address and support IPv6

### DIFF
--- a/util.go
+++ b/util.go
@@ -18,7 +18,7 @@ func debug(args ...string) {
 	}
 }
 
-// findIP returns the IPv4 address of the passed interface, and an error
+// findIP returns the IP address of the passed interface, and an error
 func findIP(iface net.Interface) (string, error) {
 	addrs, err := iface.Addrs()
 	if err != nil {
@@ -26,7 +26,12 @@ func findIP(iface net.Interface) (string, error) {
 	}
 	for _, addr := range addrs {
 		if ipnet, ok := addr.(*net.IPNet); ok {
-			return ipnet.IP.String(), nil
+			if !ipnet.IP.IsLinkLocalUnicast() {
+				if ipnet.IP.To4() != nil {
+					return ipnet.IP.String(), nil
+				}
+				return "[" + ipnet.IP.String() + "]", nil
+			}
 		}
 	}
 	return "", errors.New("Unable to find an IP for this interface")


### PR DESCRIPTION
This PR changes findIP to skip any link local ip addresses and to properly return IPv6 addresses enclosed within brackets. This will add support for IPv6 while also preventing the binding errors which occur for many people on macos.
