### PR TITLE
fix Content-Type header in http response

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,6 @@ func main() {
 		w.Header().Set("Content-Disposition",
 			"attachment; filename="+content.Name())
 
-		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
 		http.ServeFile(w, r, content.Path)
 		if content.ShouldBeDeleted {
 			if err := content.Delete(); err != nil {


### PR DESCRIPTION
A request does not carry Content-Type information in its headers, just leave it unset, and http.ServeFile will set it automatically.

