### PR TITLE
Added a flag for reversing the QR code color

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
+- `-reverse` reverses the color of the qr code
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
-- `-reverse` reverses the color of the qr code
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
-- `-reverse` reverses the qr code color
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
+- `-reverse` reverses the qr code color
 
 
 ## Authors

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
+var reverseFlag = flag.Bool("reverse", false, "reverse the color of qr code")
 
 func main() {
 	flag.Parse()
@@ -51,10 +52,25 @@ func main() {
 	fmt.Println("Make sure that your smartphone is connected to the same WiFi network as this computer.")
 
 	qrConfig := qrterminal.Config{
-		Level:     qrterminal.L,
-		Writer:    os.Stdout,
-		BlackChar: qrterminal.WHITE,
-		WhiteChar: qrterminal.BLACK,
+		HalfBlocks:     true,
+		Level:          qrterminal.L,
+		Writer:         os.Stdout,
+		BlackWhiteChar: qrterminal.WHITE_BLACK,
+		BlackChar:      qrterminal.WHITE_WHITE,
+		WhiteBlackChar: qrterminal.BLACK_WHITE,
+		WhiteChar:      qrterminal.BLACK_BLACK,
+	}
+
+	if *reverseFlag == true {
+		qrConfig = qrterminal.Config{
+			HalfBlocks:     true,
+			Level:          qrterminal.L,
+			Writer:         os.Stdout,
+			BlackWhiteChar: qrterminal.BLACK_WHITE,
+			BlackChar:      qrterminal.BLACK_BLACK,
+			WhiteBlackChar: qrterminal.WHITE_BLACK,
+			WhiteChar:      qrterminal.WHITE_WHITE,
+		}
 	}
 
 	qrterminal.GenerateWithConfig(fmt.Sprintf("http://%s", listener.Addr().String()), qrConfig)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
+var reverseFlag = flag.Bool("reverse", false, "reverse the colors of the QR code")
 
 func main() {
 	flag.Parse()
@@ -49,8 +50,20 @@ func main() {
 	// Generate the QR code
 	fmt.Println("Scan the following QR to start the download.")
 	fmt.Println("Make sure that your smartphone is connected to the same WiFi network as this computer.")
-	qrterminal.GenerateHalfBlock(fmt.Sprintf("http://%s", listener.Addr().String()),
-		qrterminal.L, os.Stdout)
+
+	qrConfig := qrterminal.Config{
+		Level:     qrterminal.L,
+		Writer:    os.Stdout,
+		BlackChar: qrterminal.BLACK,
+		WhiteChar: qrterminal.WHITE,
+	}
+
+	if *reverseFlag == true {
+		qrConfig.BlackChar = qrterminal.WHITE
+		qrConfig.WhiteChar = qrterminal.BLACK
+	}
+
+	qrterminal.GenerateWithConfig(fmt.Sprintf("http://%s", listener.Addr().String()), qrConfig)
 
 	// Define a default handler for the requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
-var reverseFlag = flag.Bool("reverse", false, "reverse the colors of the QR code")
 
 func main() {
 	flag.Parse()
@@ -54,13 +53,8 @@ func main() {
 	qrConfig := qrterminal.Config{
 		Level:     qrterminal.L,
 		Writer:    os.Stdout,
-		BlackChar: qrterminal.BLACK,
-		WhiteChar: qrterminal.WHITE,
-	}
-
-	if *reverseFlag == true {
-		qrConfig.BlackChar = qrterminal.WHITE
-		qrConfig.WhiteChar = qrterminal.BLACK
+		BlackChar: qrterminal.WHITE,
+		WhiteChar: qrterminal.BLACK,
 	}
 
 	qrterminal.GenerateWithConfig(fmt.Sprintf("http://%s", listener.Addr().String()), qrConfig)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
-var reverseFlag = flag.Bool("reverse", false, "reverse the color of qr code")
 
 func main() {
 	flag.Parse()
@@ -55,22 +54,10 @@ func main() {
 		HalfBlocks:     true,
 		Level:          qrterminal.L,
 		Writer:         os.Stdout,
-		BlackWhiteChar: qrterminal.WHITE_BLACK,
-		BlackChar:      qrterminal.WHITE_WHITE,
-		WhiteBlackChar: qrterminal.BLACK_WHITE,
-		WhiteChar:      qrterminal.BLACK_BLACK,
-	}
-
-	if *reverseFlag == true {
-		qrConfig = qrterminal.Config{
-			HalfBlocks:     true,
-			Level:          qrterminal.L,
-			Writer:         os.Stdout,
-			BlackWhiteChar: qrterminal.BLACK_WHITE,
-			BlackChar:      qrterminal.BLACK_BLACK,
-			WhiteBlackChar: qrterminal.WHITE_BLACK,
-			WhiteChar:      qrterminal.WHITE_WHITE,
-		}
+		BlackWhiteChar: "\u001b[37m\u001b[40m\u2584\u001b[0m",
+		BlackChar:      "\u001b[30m\u001b[40m\u2588\u001b[0m",
+		WhiteBlackChar: "\u001b[30m\u001b[47m\u2585\u001b[0m",
+		WhiteChar:      "\u001b[37m\u001b[47m\u2588\u001b[0m",
 	}
 
 	qrterminal.GenerateWithConfig(fmt.Sprintf("http://%s", listener.Addr().String()), qrConfig)


### PR DESCRIPTION
Added `-reverse` for make is suitable for terminals with a lighter background and darker foreground.
Wishlist item #12 