### PR TITLE
Return an error when no interfaces are available

### DIFF
--- a/util.go
+++ b/util.go
@@ -82,6 +82,9 @@ func getAddress(config *Config) (string, error) {
 		}
 		filteredIfaces = append(filteredIfaces, iface)
 	}
+	if len(filteredIfaces) == 0 {
+		return "", errors.New("No network interface available.")
+	}
 	if len(filteredIfaces) == 1 {
 		candidateInterface = &filteredIfaces[0]
 		ip, err := findIP(*candidateInterface)


### PR DESCRIPTION
It is possible that the filtered interface list could end up being empty. PR changes getAddress to return an error in this case.