### PR TITLE
add -remote flag for remote download

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
-- `-remote` if set true, will use public ip address, default is false
-- `-ssh` specify ssh port, default is 22, this is for generate scp command
+- `-external` if set true, will use public ip address, default is false
+- `-cert` if set true, will start a qrcode for downloading the certification file for https, default is false
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-# This is forked from [qr-filetransfer](https://github.com/claudiodangelis/qr-filetransfer)
-Now this can download from a remote server.
-
-Port should be specified, default is 9527.
-
-Also generate a `scp` command for copy paste.
-## Install
-
-```
-go get github.com/FrontMage/qr-filetransfer
-```
-
 # qr-filetransfer
 
 Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
@@ -82,6 +70,8 @@ qr-filetransfer /path/to/directory
 - `-debug` increases verbosity
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
+- `-remote` if set true, will use public ip address, default is false
+- `-ssh` specify ssh port, default is 22, this is for generate scp command
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+### This is forked from https://github.com/claudiodangelis/qr-filetransfer
+Now this can download from a remote server.
+
+Port should be specified, default is 9527.
+
+Also generate a `scp` command for copy paste.
+
 # qr-filetransfer
 
 Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-### This is forked from https://github.com/claudiodangelis/qr-filetransfer
+# This is forked from [qr-filetransfer](https://github.com/claudiodangelis/qr-filetransfer)
 Now this can download from a remote server.
 
 Port should be specified, default is 9527.
 
 Also generate a `scp` command for copy paste.
+## Install
+
+```
+go get github.com/FrontMage/qr-filetransfer
+```
 
 # qr-filetransfer
 

--- a/cert.go
+++ b/cert.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+)
+
+// This is copied from https://github.com/bettercap/bettercap/blob/master/tls/cert.go#L55 with a few modifications
+// Generate generate cert on the given certPath
+// Generate corresponding key will be in keyPath
+func Generate(certPath string, keyPath string) error {
+	keyfile, err := os.Create(keyPath)
+	if err != nil {
+		return err
+	}
+	defer keyfile.Close()
+
+	certfile, err := os.Create(certPath)
+	if err != nil {
+		return err
+	}
+	defer certfile.Close()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now()
+	aYear := time.Duration(365*24) * time.Hour
+	notAfter := notBefore.Add(aYear)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Country:            []string{"ZH"},
+			Locality:           []string{"WUHAN"},
+			Organization:       []string{"QR-FileTransfer"},
+			OrganizationalUnit: []string{"Development"},
+			CommonName:         "claudiodangelis/qr-filetransfer",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+
+	cert_raw, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	if err := pem.Encode(keyfile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return err
+	}
+
+	return pem.Encode(certfile, &pem.Block{Type: "CERTIFICATE", Bytes: cert_raw})
+}

--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 const (
 	// TODO: windows may require a different path
 	// https cert path
-	certPath = "/var/tmp/qr-filetransfer/cert"
+	certPath = "/var/tmp/qr-filetransfer.cert"
 	// https key path
-	keyPath = "/var/tmp/qr-filetransfer/key"
+	keyPath = "/var/tmp/qr-filetransfer.key"
 )
 
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
 var portFlag = flag.Int("port", 9527, "specify port, default is a 9527")
+var remoteFlag = flag.Bool("remote", false, "if set true, will use public ip address, default is false")
 
 // TODO this feature is not done
 var sshPortFlag = flag.Int("ssh", 22, "specify ssh port, default is 22, this is for generate scp command")
@@ -34,9 +35,16 @@ func main() {
 	}
 
 	// Get addresses
-	address, err := getAddress(&config)
-	if err != nil {
-		log.Fatalln(err)
+	var address string
+	var err error
+	if *remoteFlag {
+		if address, err = GetPublicIP(); err != nil {
+			log.Fatalln(err)
+		}
+	} else {
+		if address, err = getAddress(&config); err != nil {
+			log.Fatalln(err)
+		}
 	}
 
 	content, err := getContent(flag.Args())
@@ -76,5 +84,4 @@ func main() {
 	})
 	// Start a new server bound to the chosen address on a 9527 or specified port
 	log.Fatalln(http.ListenAndServe(fmt.Sprintf("%s:%d", address, *portFlag), nil))
-
 }

--- a/main.go
+++ b/main.go
@@ -83,5 +83,5 @@ func main() {
 		os.Exit(0)
 	})
 	// Start a new server bound to the chosen address on a 9527 or specified port
-	log.Fatalln(http.ListenAndServe(fmt.Sprintf("%s:%d", address, *portFlag), nil))
+	log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", *portFlag), nil))
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ var debugFlag = flag.Bool("debug", false, "increase verbosity")
 var portFlag = flag.Int("port", 9527, "specify port, default is a 9527")
 var remoteFlag = flag.Bool("remote", false, "if set true, will use public ip address, default is false")
 
-// TODO this feature is not done
 var sshPortFlag = flag.Int("ssh", 22, "specify ssh port, default is 22, this is for generate scp command")
 
 func main() {
@@ -61,7 +60,9 @@ func main() {
 
 	// Generate the QR code
 	fmt.Println("Scan the following QR to start the download.")
-	fmt.Printf("scp %s:%s ./\n", address, dir)
+	if *remoteFlag {
+		fmt.Printf("scp -P %d %s:%s ./\n", *sshPortFlag, address, dir)
+	}
 	qrterminal.GenerateHalfBlock(fmt.Sprintf("http://%s:%d", address, *portFlag),
 		qrterminal.L, os.Stdout)
 

--- a/main.go
+++ b/main.go
@@ -22,27 +22,42 @@ var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")
 var forceFlag = flag.Bool("force", false, "ignore saved configuration")
 var debugFlag = flag.Bool("debug", false, "increase verbosity")
 var portFlag = flag.Int("port", 9527, "specify port, default is a 9527")
-var remoteFlag = flag.Bool("remote", false, "if set true, will use public ip address, default is false")
+var externalFlag = flag.Bool("external", false, "if set true, will use public ip address, default is false")
+var certFlag = flag.Bool("cert", false, "if set true, will start a qrcode for downloading the certification file for https, default is false")
+var address string
+var config Config
+var content Content
 
 func main() {
 	flag.Parse()
-	config := LoadConfig()
+	config = LoadConfig()
 	if *forceFlag == true {
 		config.Delete()
 		config = LoadConfig()
 	}
 
 	// Check how many arguments are passed
-	if len(flag.Args()) == 0 {
+	if len(flag.Args()) == 0 && !*certFlag {
 		log.Fatalln("At least one argument is required")
 	}
 
 	// Get addresses
-	var address string
 	var err error
-	if *remoteFlag {
+	if *externalFlag || *certFlag {
 		if address, err = GetPublicIP(); err != nil {
 			log.Fatalln(err)
+		}
+		if *certFlag {
+			// generate cert file
+			_, certStatsErr := os.Stat(certPath)
+			_, keyStatsErr := os.Stat(certPath)
+			if certStatsErr != nil || keyStatsErr != nil {
+				if err := Generate(certPath, keyPath); err != nil {
+					log.Fatalln(err)
+				}
+			}
+			serveCert()
+			return
 		}
 	} else {
 		if address, err = getAddress(&config); err != nil {
@@ -50,24 +65,26 @@ func main() {
 		}
 	}
 
-	// generate cert file
-	if err := Generate(certPath, keyPath); err != nil {
-		log.Fatalln(err)
-	}
-
-	content, err := getContent(flag.Args())
+	content, err = getContent(flag.Args())
 	if err != nil {
 		log.Fatalln(err)
 	}
 
+	if *externalFlag {
+		serveHTTPS()
+	} else {
+		serveHTTP()
+	}
+}
+
+func serveHTTP() {
 	// Generate the QR code
 	fmt.Println("Scan the following QR to start the download.")
-	protocol := "http"
-	if *remoteFlag {
-		protocol += "s"
-	}
-	qrterminal.GenerateHalfBlock(fmt.Sprintf("%s://%s:%d", protocol, address, *portFlag),
-		qrterminal.L, os.Stdout)
+	qrterminal.GenerateHalfBlock(
+		fmt.Sprintf("http://%s:%d/", address, *portFlag),
+		qrterminal.L,
+		os.Stdout,
+	)
 
 	// Define a default handler for the requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +103,69 @@ func main() {
 		}
 		os.Exit(0)
 	})
+	log.Fatalln(
+		http.ListenAndServe(
+			fmt.Sprintf(":%d", *portFlag),
+			nil,
+		),
+	)
+}
+
+func serveCert() {
+	fmt.Println("Scan the following QR to download the certification file")
+	qrterminal.GenerateHalfBlock(
+		fmt.Sprintf("http://%s:%d/cert", address, *portFlag),
+		qrterminal.L,
+		os.Stdout,
+	)
+
+	// Define a cert handler for cert download
+	http.HandleFunc("/cert", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition",
+			"attachment; filename="+content.Name())
+
+		w.Header().Set("Content-Type", "application/x-x509-ca-cert")
+		http.ServeFile(w, r, certPath)
+		if err := config.Update(); err != nil {
+			log.Println("Unable to update configuration", err)
+		}
+	})
+
+	// Start a new server bound to the chosen address on a 9527 or specified port
+	log.Fatalln(
+		http.ListenAndServe(
+			fmt.Sprintf(":%d", *portFlag),
+			nil,
+		),
+	)
+}
+
+func serveHTTPS() {
+	fmt.Println("Scan the following QR to start the download.")
+	qrterminal.GenerateHalfBlock(
+		fmt.Sprintf("https://%s:%d/", address, *portFlag),
+		qrterminal.L,
+		os.Stdout,
+	)
+
+	// Define a default handler for the requests
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition",
+			"attachment; filename="+content.Name())
+
+		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+		http.ServeFile(w, r, content.Path)
+		if content.ShouldBeDeleted {
+			if err := content.Delete(); err != nil {
+				log.Println("Unable to delete the content from disk", err)
+			}
+		}
+		if err := config.Update(); err != nil {
+			log.Println("Unable to update configuration", err)
+		}
+		os.Exit(0)
+	})
+
 	// Start a new server bound to the chosen address on a 9527 or specified port
 	log.Fatalln(
 		http.ListenAndServeTLS(

--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
+	// TODO: windows may require a different path
 	// https cert path
-	certPath = "./cert"
+	certPath = "/var/tmp/qr-filetransfer/cert"
 	// https key path
-	keyPath = "./key"
+	keyPath = "/var/tmp/qr-filetransfer/key"
 )
 
 var zipFlag = flag.Bool("zip", false, "zip the contents to be transfered")

--- a/publicip.go
+++ b/publicip.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"errors"
+	"net"
+)
+
+// GetPublicIP returns public ip address
+func GetPublicIP() (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String(), nil
+			}
+		}
+	}
+	return "", errors.New("Failed to find public ip address")
+}

--- a/publicip.go
+++ b/publicip.go
@@ -1,23 +1,23 @@
 package main
 
 import (
-	"errors"
-	"net"
+	"bytes"
+	"io/ioutil"
+	"net/http"
 )
 
 // GetPublicIP returns public ip address
 func GetPublicIP() (string, error) {
-	addrs, err := net.InterfaceAddrs()
+	rsp, err := http.Get("http://checkip.amazonaws.com")
+	if err != nil {
+		return "", err
+	}
+	defer rsp.Body.Close()
+
+	buf, err := ioutil.ReadAll(rsp.Body)
 	if err != nil {
 		return "", err
 	}
 
-	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
-				return ipnet.IP.String(), nil
-			}
-		}
-	}
-	return "", errors.New("Failed to find public ip address")
+	return string(bytes.TrimSpace(buf)), nil
 }


### PR DESCRIPTION
Add `-remote` for remote download.

Because there is now no https support, some user might want to use `scp` instead http download.