### PR TITLE
Add support for parallel downloads

### DIFF
--- a/LICENSE.GO
+++ b/LICENSE.GO
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -8,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/mattn/go-colorable"
 	"github.com/mdp/qrterminal"
@@ -31,23 +34,24 @@ func main() {
 		log.Fatalln("At least one argument is required")
 	}
 
-	// Get addresses
+	// Get Content
+	content, err := getContent(flag.Args())
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Get address
 	address, err := getAddress(&config)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Create a net.Listener bound to the choosen address on a random port
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", address))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer listener.Close()
-
-	content, err := getContent(flag.Args())
+	// Get a TCP Listener bound to a random port
+	listener, err := net.Listen("tcp", address+":0")
 	if err != nil {
 		log.Fatalln(err)
 	}
+	address = fmt.Sprintf("%s:%d", address, listener.Addr().(*net.TCPAddr).Port)
 
 	randomPath := getRandomURLPath()
 
@@ -76,24 +80,88 @@ func main() {
 
 	qrterminal.GenerateWithConfig(generatedAddress, qrConfig)
 
+	// Create a server
+	srv := &http.Server{Addr: address}
+
+	// Create channel to send message to stop server
+	stop := make(chan bool)
+
+	// Wait for stop and then shutdown the server,
+	go func() {
+		<-stop
+		if err := srv.Shutdown(context.Background()); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	// The handler adds and removes from the sync.WaitGroup
+	// When the group is zero all requests are completed
+	// and the server is shutdown
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Wait()
+		stop <- true
+	}()
+
+	// Create cookie used to verify request is coming from first client to connect
+	cookie := http.Cookie{Name: "qr-filetransfer", Value: ""}
+
+	var initCookie sync.Once
+
 	// Define a default handler for the requests
 	route := fmt.Sprintf("/%s", randomPath)
 	http.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+		// If the cookie's value is empty this is the first connection
+		// and the initialize the cookie.
+		// Wrapped in a sync.Once to avoid potential race conditions
+		if cookie.Value == "" {
+			if !strings.HasPrefix(r.Header.Get("User-Agent"), "Mozilla") {
+				http.Error(w, "", http.StatusOK)
+				return
+			}
+			initCookie.Do(func() {
+				value, err := getSessionID()
+				if err != nil {
+					log.Println("Unable to generate session ID", err)
+					stop <- true
+				}
+				cookie.Value = value
+				http.SetCookie(w, &cookie)
+			})
+		} else {
+			// Check for the expected cookie and value
+			// If it is missing or doesn't match
+			// return a 404 status
+			rcookie, err := r.Cookie(cookie.Name)
+			if err != nil || rcookie.Value != cookie.Value {
+				http.Error(w, "", http.StatusNotFound)
+				return
+			}
+			// If the cookie exits and matches
+			// this is an aadditional request.
+			// Increment the waitgroup
+			wg.Add(1)
+		}
+
+		defer wg.Done()
 		w.Header().Set("Content-Disposition",
 			"attachment; filename="+content.Name())
-
 		http.ServeFile(w, r, content.Path)
-		if content.ShouldBeDeleted {
-			if err := content.Delete(); err != nil {
-				log.Println("Unable to delete the content from disk", err)
-			}
-		}
-		if err := config.Update(); err != nil {
-			log.Println("Unable to update configuration", err)
-		}
-		os.Exit(0)
 	})
-	// Start a new server using the listener bound to the choosen address on a random port
-	log.Fatalln(http.Serve(listener, nil))
+
+	// Enable TCP keepalives on the listener and start serving requests
+	if err := (srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})); err != http.ErrServerClosed {
+		log.Fatalln(err)
+	}
+
+	if content.ShouldBeDeleted {
+		if err := content.Delete(); err != nil {
+			log.Println("Unable to delete the content from disk", err)
+		}
+	}
+	if err := config.Update(); err != nil {
+		log.Println("Unable to update configuration", err)
+	}
 
 }

--- a/tcpKeepAliveListener.go
+++ b/tcpKeepAliveListener.go
@@ -1,0 +1,25 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.GO file.
+
+package main
+
+import (
+	"net"
+	"time"
+)
+
+// Apply TCP keepalives to the listener
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/util.go
+++ b/util.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -144,4 +147,13 @@ func getRandomURLPath() string {
 	timeNum := time.Now().UTC().UnixNano()
 	alphaString := strconv.FormatInt(timeNum, 36)
 	return alphaString[len(alphaString)-4:]
+}
+
+// getSessionID returns a base64 encoded string of 40 random characters
+func getSessionID() (string, error) {
+	randbytes := make([]byte, 40)
+	if _, err := io.ReadFull(rand.Reader, randbytes); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(randbytes), nil
 }


### PR DESCRIPTION
Supports parallel downloads while still having the application close when the download is complete. It accomplishes this by creating a sync.WaitGroup which the handler adds and decrements. When it reaches zero, all requests have been serviced, it shuts the server down, removes deletable files, updates the config and exits. To ensure that only a single transfer can occur it creates and attaches a session cookie which is checked for upon each request. Any request after the initial one without the cookie receives a 404 status.

It also tries to deal with the issue of barcode apps causing premature closure. For the first request it checks if the User-Agent begins with "Mozilla" which basically all mobile and desktop browser agent strings do. If it doesn't a 200 status is returned and the handler function immediately returns. Not elegant but hopefully it works. Might not catch all barcode apps but it does catch the couple I tried including the popular ZXing app and is easier than trying to maintain a blacklist of user agents.

Also enables TCP keepalives on the listener which means it fully implements the feature of ListenAndServer. This code is taken from the golang net library. The Google license and copyright notice is properly included.