### PR TITLE
Add reference to node.js clone, "quick-transfer".

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ qr-filetransfer /path/to/directory
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
 
-## Related
+## Clones and Similar Projects
 
 - [quick-transfer](https://github.com/CodeMan99/quick-transfer) - Node.js clone of this project.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ qr-filetransfer /path/to/directory
 - `-force` ignores saved configuration
 - `-zip` zips the content before transferring it
 
+## Related
+
+- [quick-transfer](https://github.com/CodeMan99/quick-transfer) - Node.js clone of this project.
 
 ## Authors
 


### PR DESCRIPTION
Thought your project was pretty neat. Decided to write a node.js clone/fork and wondered if you'd like to reference my project?

Totally cool if you don't want to.