### PR TITLE
Gracefully shutdown when a signal is received

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
 	"sync"
@@ -92,6 +93,14 @@ func main() {
 		if err := srv.Shutdown(context.Background()); err != nil {
 			log.Println(err)
 		}
+	}()
+
+	// Gracefully shutdown when an OS signal is received
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig)
+	go func() {
+		<-sig
+		stop <- true
 	}()
 
 	// The handler adds and removes from the sync.WaitGroup


### PR DESCRIPTION
When an OS signal is received, such as when cntrl-c is pressed, the program will gracefully exit using the same routine as when a file transfer completes.