### PR TITLE
Support user specified port

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ import (
 // Config holds the values
 type Config struct {
 	Iface string `json:"interface"`
+	Port  int    `json:"port,omityempty"`
 }
 
 func configFile() (string, error) {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -47,8 +48,13 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Get a TCP Listener bound to a random port
-	listener, err := net.Listen("tcp", address+":0")
+	port := ":0"
+	if config.Port > 0 {
+		port = ":" + strconv.FormatInt(int64(config.Port), 10)
+	}
+
+	// Get a TCP Listener bound to a random port, or the user specificed port
+	listener, err := net.Listen("tcp", address+port)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
What a great project, thanks!

The firewall on my laptop basically drops all incoming connections, and I'd like to open just one port for qr-filetransfer (and any other temporary external tcp process). This requires dictating the port that should be listened on.

If the user does nothing, qr-filetransfer will continue behaving as it has. It will just add `"Port": 0` to the config file. If the user changes that number, the server will listen to that port.

Please let me know if you think this would be a useful addition. Let me know if there are any changes you would like on account of coding style or organization, etc.