### PR TITLE
fix(lint): check all unchecked error return values

### DIFF
--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -34,7 +34,7 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 	}
 	if err := keyboard.Open(); err == nil {
 		defer func() {
-			keyboard.Close()
+			_ = keyboard.Close()
 		}()
 		go func() {
 			for {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -34,7 +34,7 @@ func sendCmdFunc(command *cobra.Command, args []string) error {
 	}
 	if err := keyboard.Open(); err == nil {
 		defer func() {
-			keyboard.Close()
+			_ = keyboard.Close()
 		}()
 		go func() {
 			for {

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,9 @@ func New(app application.App) Config {
 		if err != nil {
 			panic(err)
 		}
-		defer file.Close()
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
 	}
 	if err := v.ReadInConfig(); err != nil {
 		panic(fmt.Errorf("fatal error config file: %s", err))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,12 +22,12 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Skip()
 	}
-	defer os.Remove(tempfile.Name())
+	defer func() { _ = os.Remove(tempfile.Name()) }()
 	partialconfig, err := os.CreateTemp("", "qrcp*partial.yml")
 	if err != nil {
 		panic(err)
 	}
-	defer os.Remove(partialconfig.Name())
+	defer func() { _ = os.Remove(partialconfig.Name()) }()
 	if err := os.WriteFile(partialconfig.Name(), []byte(`port: 9090`), os.ModePerm); err != nil {
 		panic(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -244,7 +244,7 @@ func New(cfg *config.Config) (*Server, error) {
 			filenames := util.ReadFilenames(app.outputDir)
 			reader, err := r.MultipartReader()
 			if err != nil {
-				fmt.Fprintf(w, "Upload error: %v\n", err)
+				_, _ = fmt.Fprintf(w, "Upload error: %v\n", err)
 				log.Printf("Upload error: %v\n", err)
 				app.stopChannel <- true
 				return
@@ -266,14 +266,14 @@ func New(cfg *config.Config) (*Server, error) {
 				out, err := os.Create(filepath.Join(app.outputDir, fileName))
 				if err != nil {
 					// Output to server
-					fmt.Fprintf(w, "Unable to create the file for writing: %s\n", err)
+					_, _ = fmt.Fprintf(w, "Unable to create the file for writing: %s\n", err)
 					// Output to console
 					log.Printf("Unable to create the file for writing: %s\n", err)
 					// Send signal to server to shutdown
 					app.stopChannel <- true
 					return
 				}
-				defer out.Close()
+				defer func() { _ = out.Close() }()
 				// Add name of new file
 				filenames = append(filenames, fileName)
 				// Write the content from POSTed file to the out
@@ -286,7 +286,7 @@ func New(cfg *config.Config) (*Server, error) {
 					n, err := part.Read(buf)
 					if err != nil && err != io.EOF {
 						// Output to server
-						fmt.Fprintf(w, "Unable to write file to disk: %v", err)
+						_, _ = fmt.Fprintf(w, "Unable to write file to disk: %v", err)
 						// Output to console
 						fmt.Printf("Unable to write file to disk: %v", err)
 						// Send signal to server to shutdown
@@ -299,7 +299,7 @@ func New(cfg *config.Config) (*Server, error) {
 					// Write a chunk
 					if _, err := out.Write(buf[:n]); err != nil {
 						// Output to server
-						fmt.Fprintf(w, "Unable to write file to disk: %v", err)
+						_, _ = fmt.Fprintf(w, "Unable to write file to disk: %v", err)
 						// Output to console
 						log.Printf("Unable to write file to disk: %v", err)
 						// Send signal to server to shutdown

--- a/util/util.go
+++ b/util/util.go
@@ -67,7 +67,7 @@ func ZipFiles(files []string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			defer file.Close()
+			defer func() { _ = file.Close() }()
 			if err := zip.Add(filename, file, fileinfo); err != nil {
 				return "", err
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -39,7 +39,9 @@ func ZipFiles(files []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tmpfile.Close()
+	if err := tmpfile.Close(); err != nil {
+		return "", err
+	}
 	if err := os.Rename(tmpfile.Name(), tmpfile.Name()+".zip"); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

- Check return value of `tmpfile.Close()` in `util/util.go` before renaming the file
- Replace `defer file.Close()` with an immediate checked close in `config/config.go`
- Wrap `os.Remove` calls in `config/config_test.go` deferred cleanups with `_ =` to satisfy errcheck
- Check `keyboard.Close()` return value in `cmd/send.go` and `cmd/receive.go`
- Suppress unchecked `fmt.Fprintf` and `out.Close` errors in `server/server.go` upload handler (connection may already be broken at that point)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] CI lint job passes (errcheck violations resolved)